### PR TITLE
Add Software Requirements structure with traceability

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -203,6 +203,13 @@
                     <!-- Dynamically populated -->
                 </ul>
             </div>
+            
+            <div class="nav-section">
+                <h3>Software Requirements</h3>
+                <ul id="softwareReqsList">
+                    <!-- Dynamically populated -->
+                </ul>
+            </div>
         </div>
         
         <div class="content">
@@ -238,6 +245,22 @@
             productRequirements: [
                 { id: 'PRQ-001', title: 'Login Functionality', path: 'traceability/product_requirements/PRQ-001.md' },
                 { id: 'PRQ-008', title: 'Password Requirements', path: 'traceability/product_requirements/PRQ-008.md' }
+            ],
+            softwareRequirements: [
+                { id: 'SWR-001', title: 'User Authentication Module', path: 'traceability/software_requirements/SWR-001.md' },
+                { id: 'SWR-002', title: 'Password Validation Service', path: 'traceability/software_requirements/SWR-002.md' },
+                { id: 'SWR-003', title: 'Session Management Component', path: 'traceability/software_requirements/SWR-003.md' },
+                { id: 'SWR-004', title: 'Security Encryption Module', path: 'traceability/software_requirements/SWR-004.md' },
+                { id: 'SWR-005', title: 'Login Form UI Component', path: 'traceability/software_requirements/SWR-005.md' },
+                { id: 'SWR-006', title: 'Authentication API Endpoint', path: 'traceability/software_requirements/SWR-006.md' },
+                { id: 'SWR-007', title: 'User Database Interface', path: 'traceability/software_requirements/SWR-007.md' },
+                { id: 'SWR-008', title: 'Login Attempt Logging Service', path: 'traceability/software_requirements/SWR-008.md' },
+                { id: 'SWR-009', title: 'Account Lockout Manager', path: 'traceability/software_requirements/SWR-009.md' },
+                { id: 'SWR-010', title: 'Password Strength Calculator', path: 'traceability/software_requirements/SWR-010.md' },
+                { id: 'SWR-011', title: 'Password Policy Configuration', path: 'traceability/software_requirements/SWR-011.md' },
+                { id: 'SWR-012', title: 'Password History Tracker', path: 'traceability/software_requirements/SWR-012.md' },
+                { id: 'SWR-013', title: 'Password Reset Service', path: 'traceability/software_requirements/SWR-013.md' },
+                { id: 'SWR-014', title: 'Regex Validation Library', path: 'traceability/software_requirements/SWR-014.md' }
             ]
         };
         
@@ -245,6 +268,7 @@
         function initNavigation() {
             const userNeedsList = document.getElementById('userNeedsList');
             const productReqsList = document.getElementById('productReqsList');
+            const softwareReqsList = document.getElementById('softwareReqsList');
             
             // Populate user needs
             documents.userNeeds.forEach(doc => {
@@ -274,6 +298,21 @@
                 };
                 li.appendChild(a);
                 productReqsList.appendChild(li);
+            });
+            
+            // Populate software requirements
+            documents.softwareRequirements.forEach(doc => {
+                const li = document.createElement('li');
+                const a = document.createElement('a');
+                a.href = `#${doc.path}`;
+                a.textContent = `${doc.id}: ${doc.title}`;
+                a.onclick = (e) => {
+                    e.preventDefault();
+                    loadDocument(doc.path);
+                    setActiveLink(a);
+                };
+                li.appendChild(a);
+                softwareReqsList.appendChild(li);
             });
         }
         
@@ -433,6 +472,10 @@
                             <div class="stat-number">${documents.productRequirements.length}</div>
                             <div class="stat-label">Product Requirements</div>
                         </div>
+                        <div class="stat">
+                            <div class="stat-number">${documents.softwareRequirements.length}</div>
+                            <div class="stat-label">Software Requirements</div>
+                        </div>
                     </div>
                     
                     <h2 style="margin-top: 50px;">Getting Started</h2>
@@ -442,6 +485,7 @@
                     <ul style="text-align: left; max-width: 600px; margin: 0 auto;">
                         <li><strong>User Needs:</strong> High-level requirements from the user's perspective</li>
                         <li><strong>Product Requirements:</strong> Detailed technical specifications that implement user needs</li>
+                        <li><strong>Software Requirements:</strong> Implementation-level requirements that realize product requirements</li>
                     </ul>
                     
                     <p style="text-align: left; max-width: 600px; margin: 20px auto;">

--- a/docs/traceability/software_requirements/SWR-001.md
+++ b/docs/traceability/software_requirements/SWR-001.md
@@ -1,0 +1,15 @@
+# SWR-001: User Authentication Module
+
+## Requirement Statement
+The system shall implement a user authentication module that validates credentials against the user database and returns authentication status.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- Authentication service implementation
+- Credential validation logic
+- Integration with user database
+
+## Category
+Module

--- a/docs/traceability/software_requirements/SWR-002.md
+++ b/docs/traceability/software_requirements/SWR-002.md
@@ -1,0 +1,15 @@
+# SWR-002: Password Validation Service
+
+## Requirement Statement
+The system shall implement a password validation service that enforces complexity requirements including minimum length, character types, and special characters.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Password complexity checker
+- Real-time validation feedback
+- Configuration of validation rules
+
+## Category
+Service

--- a/docs/traceability/software_requirements/SWR-003.md
+++ b/docs/traceability/software_requirements/SWR-003.md
@@ -1,0 +1,15 @@
+# SWR-003: Session Management Component
+
+## Requirement Statement
+The system shall implement session management with secure token generation, validation, and expiration handling.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- Session token generation
+- Token validation and refresh
+- Session expiration handling
+
+## Category
+Component

--- a/docs/traceability/software_requirements/SWR-004.md
+++ b/docs/traceability/software_requirements/SWR-004.md
@@ -1,0 +1,15 @@
+# SWR-004: Security Encryption Module
+
+## Requirement Statement
+The system shall implement secure password hashing using industry-standard encryption algorithms.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Password hashing implementation
+- Salt generation and management
+- Encryption algorithm selection
+
+## Category
+Module

--- a/docs/traceability/software_requirements/SWR-005.md
+++ b/docs/traceability/software_requirements/SWR-005.md
@@ -1,0 +1,15 @@
+# SWR-005: Login Form UI Component
+
+## Requirement Statement
+The system shall provide a user interface component for username and password entry with client-side validation.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- Frontend login form implementation
+- Input validation and error display
+- Accessibility compliance
+
+## Category
+UI Component

--- a/docs/traceability/software_requirements/SWR-006.md
+++ b/docs/traceability/software_requirements/SWR-006.md
@@ -1,0 +1,15 @@
+# SWR-006: Authentication API Endpoint
+
+## Requirement Statement
+The system shall expose a REST API endpoint for authentication requests with proper request/response handling.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- RESTful API design
+- Request validation
+- Response formatting
+
+## Category
+API

--- a/docs/traceability/software_requirements/SWR-007.md
+++ b/docs/traceability/software_requirements/SWR-007.md
@@ -1,0 +1,15 @@
+# SWR-007: User Database Interface
+
+## Requirement Statement
+The system shall implement a database access layer for secure user credential storage and retrieval.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- Database access layer
+- Credential storage schema
+- Query optimization
+
+## Category
+Database

--- a/docs/traceability/software_requirements/SWR-008.md
+++ b/docs/traceability/software_requirements/SWR-008.md
@@ -1,0 +1,15 @@
+# SWR-008: Login Attempt Logging Service
+
+## Requirement Statement
+The system shall log all authentication attempts with timestamps, user identifiers, and success/failure status.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- Audit log implementation
+- Security event tracking
+- Log retention policies
+
+## Category
+Service

--- a/docs/traceability/software_requirements/SWR-009.md
+++ b/docs/traceability/software_requirements/SWR-009.md
@@ -1,0 +1,15 @@
+# SWR-009: Account Lockout Manager
+
+## Requirement Statement
+The system shall implement account lockout functionality after a configurable number of failed login attempts.
+
+## Parent Product Requirement
+[PRQ-001](../product_requirements/PRQ-001.md): Login Functionality
+
+## Technical Details
+- Failed attempt tracking
+- Lockout duration configuration
+- Unlock mechanism
+
+## Category
+Security Component

--- a/docs/traceability/software_requirements/SWR-010.md
+++ b/docs/traceability/software_requirements/SWR-010.md
@@ -1,0 +1,15 @@
+# SWR-010: Password Strength Calculator
+
+## Requirement Statement
+The system shall provide real-time password strength feedback with visual indicators and recommendations.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Strength calculation algorithm
+- Visual feedback indicators
+- Improvement recommendations
+
+## Category
+UI Component

--- a/docs/traceability/software_requirements/SWR-011.md
+++ b/docs/traceability/software_requirements/SWR-011.md
@@ -1,0 +1,15 @@
+# SWR-011: Password Policy Configuration Module
+
+## Requirement Statement
+The system shall provide configurable password policy settings including complexity rules and expiration periods.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Policy configuration interface
+- Rule validation engine
+- Default policy settings
+
+## Category
+Configuration Module

--- a/docs/traceability/software_requirements/SWR-012.md
+++ b/docs/traceability/software_requirements/SWR-012.md
@@ -1,0 +1,15 @@
+# SWR-012: Password History Tracker
+
+## Requirement Statement
+The system shall maintain password history to prevent users from reusing recent passwords.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Password history storage
+- Comparison algorithm
+- History retention limits
+
+## Category
+Service

--- a/docs/traceability/software_requirements/SWR-013.md
+++ b/docs/traceability/software_requirements/SWR-013.md
@@ -1,0 +1,15 @@
+# SWR-013: Password Reset Service
+
+## Requirement Statement
+The system shall provide secure password reset functionality with email verification and temporary tokens.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Reset token generation
+- Email notification integration
+- Token expiration handling
+
+## Category
+Service

--- a/docs/traceability/software_requirements/SWR-014.md
+++ b/docs/traceability/software_requirements/SWR-014.md
@@ -1,0 +1,15 @@
+# SWR-014: Regex Validation Library
+
+## Requirement Statement
+The system shall implement pattern matching utilities for password validation using regular expressions.
+
+## Parent Product Requirement
+[PRQ-008](../product_requirements/PRQ-008.md): Password Requirements
+
+## Technical Details
+- Regex pattern definitions
+- Validation utilities
+- Pattern testing framework
+
+## Category
+Library


### PR DESCRIPTION
This PR adds a complete Software Requirements structure to the QMS template:

## Changes
- Created 14 Software Requirements documents (SWR-001 through SWR-014)
- Each Software Requirement traces back to its parent Product Requirement
- Updated the documentation website to display Software Requirements

## Traceability
- **PRQ-001 (Login Functionality)**: SWR-001, SWR-003, SWR-005, SWR-006, SWR-007, SWR-008, SWR-009
- **PRQ-008 (Password Requirements)**: SWR-002, SWR-004, SWR-010, SWR-011, SWR-012, SWR-013, SWR-014

## Website Updates
- Added Software Requirements navigation section to the sidebar
- Updated home page statistics to include Software Requirements count
- Enhanced Getting Started section with Software Requirements description

---

**Created by Maestro on behalf of Tobias Czempiel**